### PR TITLE
Change shebang to support Python in other locations

### DIFF
--- a/pip.py
+++ b/pip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import argparse


### PR DESCRIPTION
Having `#!/usr/bin/python3` relies on there being that interpreter in exactly that location. However, this is not always the case:
- Python when installed from source is typically in <code>/usr/<b>local/</b>bin</code>
- When using a [`virtualenv`](https://virtualenv.pypa.io/en/latest/), it's typically located in `/path/to/venv/bin/python3`
This trick using `/usr/bin/env` (which is almost always located there) works around this problem.